### PR TITLE
Fix builder

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -28,9 +28,7 @@ pub fn build(designators: Vec<String>) -> String {
         designator.extend(build_inner(designators.0, true).chars())
     }
 
-    println!("{}", designator);
-
-    String::new()
+    designator
 }
 
 pub fn build_inner(designators: Vec<Designator>, has_paren: bool) -> String {

--- a/src/designator.rs
+++ b/src/designator.rs
@@ -142,17 +142,18 @@ impl Designator {
     pub fn is_word(&self) -> bool {
         !self.prefix.is_empty() && self.number == 0 && self.suffix.is_none()
     }
-    // pub fn prefix(&self) -> &str {
-    //     self.prefix.as_str()
-    // }
 
-    // pub fn number(&self) -> usize {
-    //     self.number
-    // }
+    pub fn prefix(&self) -> &str {
+        self.prefix.as_str()
+    }
 
-    // pub fn suffix(&self) -> Option<char> {
-    //     self.suffix
-    // }
+    pub fn number(&self) -> usize {
+        self.number
+    }
+
+    pub fn suffix(&self) -> Option<char> {
+        self.suffix
+    }
 
     pub fn has_paren(&self) -> bool {
         self.has_paren

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,14 @@ mod tests {
             "R2".to_string(),
             "(R3)".to_string(),
         ];
+
         let s = builder::build(designators);
-        assert!(s.is_empty());
+        assert_eq!(
+            r#"R1~3,5,6,8,
+(R1~3)"#
+                .to_string(),
+            s
+        );
     }
 
     #[test]
@@ -90,15 +96,6 @@ mod tests {
             TokenWithSymbol::new(Token::Identifier("abc".to_string())).symbol(),
             IDENTIFIER
         );
-
-        // 変換結果のテスト
-        let mut token = TokenWithSymbol::new(Token::Whitespace);
-        assert_eq!(token.change_symbol(COMMA), Ok(()));
-        assert_eq!(token.change_symbol(CLOSE_PAREN), Ok(()));
-        assert_eq!(token.change_symbol(OPEN_PAREN), Ok(()));
-        assert_eq!(token.change_symbol(RANGE), Ok(()));
-        assert_eq!(token.change_symbol(IDENTIFIER), Ok(()));
-        assert!(token.change_symbol('a').is_err());
 
         // 括弧で囲む
         let mut token = TokenWithSymbol::new(Token::Identifier("abc".to_string()));

--- a/src/token.rs
+++ b/src/token.rs
@@ -115,22 +115,6 @@ impl TokenWithSymbol {
         }
     }
 
-    pub fn change_symbol(&mut self, symbol: char) -> Result<(), &'static str> {
-        match symbol.to_ascii_lowercase() {
-            COMMA => (),
-            CLOSE_PAREN => (),
-            OPEN_PAREN => (),
-            RANGE => (),
-            IDENTIFIER => (),
-            c if c.is_whitespace() => (),
-            _ => return Err("invalid token symbol"),
-        }
-
-        self.symbol = symbol;
-
-        Ok(())
-    }
-
     pub fn parenthesize(&mut self) {
         self.symbol.make_ascii_uppercase();
     }


### PR DESCRIPTION
This pull request includes various changes to the Rust codebase, focusing on improving the `Designator` and `TokenWithSymbol` structs, as well as updating test cases accordingly. The most important changes include removing unnecessary methods, updating the `build` function, and enhancing test cases.

### Codebase improvements:

* [`src/builder.rs`](diffhunk://#diff-e4f794ca308aa712cbad31feb714df7cada1bbe453a30e232e45891571430263L31-R31): Updated the `build` function to return the `designator` instead of an empty string.

### `Designator` struct enhancements:

* [`src/designator.rs`](diffhunk://#diff-39e842921435b81d22594555ae02745517e6800f0598da7e30093d45799cd650L145-R156): Uncommented and reinstated the `prefix`, `number`, and `suffix` methods in the `Designator` struct.

### Test case updates:

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R27-R34): Modified the test case to check the correct output of the `build` function, ensuring it matches the expected string.
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L94-L102): Removed redundant assertions in the test case for `TokenWithSymbol`.

### `TokenWithSymbol` struct simplification:

* [`src/token.rs`](diffhunk://#diff-76ada62566331039fde44902c7d08ec1f2c977a147cdefcefc466e07cedafc4fL118-L133): Removed the `change_symbol` method from the `TokenWithSymbol` struct, as it was deemed unnecessary.